### PR TITLE
feat: periodically persist RAG indexes

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -81,6 +81,9 @@ for fold in STORAGE_DIRS.values():
 
 PROMPTS_DIR = "/root/Vox/VoxPersona/prompts"
 
+RAG_INDEX_DIR = "/root/Vox/VoxPersona/rag_indexes"
+os.makedirs(RAG_INDEX_DIR, exist_ok=True)
+
 try:
     ENC = tiktoken.encoding_for_model(REPORT_MODEL_NAME)
 except KeyError:

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -48,7 +48,7 @@ from analysis import (
     assign_roles
 )
 
-from run_analysis import run_analysis_with_spinner, run_dialog_mode, init_rags
+from run_analysis import run_analysis_with_spinner, run_dialog_mode
 
 from audio_utils import extract_audio_filename, define_audio_file_params, transcribe_audio_and_save
 from auth_utils import handle_unauthorized_user
@@ -67,7 +67,18 @@ filter_wav_document = filters.create(openai_audio_filter)
 audio_file_name_to_save = ""
 transcription_text = ""
 
-rags = init_rags()
+rags = {}
+
+
+def set_rags(new_rags: dict) -> None:
+    """Allow external modules to update loaded RAGs."""
+    global rags
+    rags = new_rags
+
+
+def get_rags() -> dict:
+    """Return currently loaded RAGs."""
+    return rags
 
 def ask_client(data: dict, text: str, state: dict, chat_id: int, app: Client):
     data["client"] = parse_name(text)
@@ -183,7 +194,10 @@ def handle_authorized_text(app: Client, user_states: dict[int, dict], message: M
         sp_th = threading.Thread(target=run_loading_animation, args=(c_id, msg.id, st_ev, app))
         sp_th.start()
         try:
-            run_dialog_mode(chat_id=c_id, app=app, text=text_, deep_search=deep, rags=rags)
+            if not rags:
+                app.send_message(c_id, "🔄 База знаний ещё загружается, попробуйте позже.")
+            else:
+                run_dialog_mode(chat_id=c_id, app=app, text=text_, deep_search=deep, rags=rags)
             return
         except Exception as e:
             logging.error(f"Ошибка: {e}")

--- a/src/main.py
+++ b/src/main.py
@@ -1,25 +1,71 @@
 import logging
-from pyrogram import Client
-from config import TELEGRAM_BOT_TOKEN, API_ID, API_HASH, SESSION_NAME
-from handlers import register_handlers
+import asyncio
+import os
+from pyrogram import Client, idle
+from config import TELEGRAM_BOT_TOKEN, API_ID, API_HASH, SESSION_NAME, RAG_INDEX_DIR
+from handlers import register_handlers, set_rags, get_rags
+from run_analysis import init_rags
 import nest_asyncio
 
 nest_asyncio.apply()
 
-if __name__ == "__main__":
+
+async def load_rags():
+    """Initialize RAG models without blocking the bot startup."""
+    logging.info("Запуск фоновой инициализации RAG моделей")
+    try:
+        rags = await asyncio.to_thread(init_rags)
+        set_rags(rags)
+        save_rags_to_disk(rags)
+        logging.info("RAG модели загружены")
+    except Exception as e:
+        logging.error(f"Ошибка при инициализации RAG моделей: {e}")
+
+
+def save_rags_to_disk(rags: dict) -> None:
+    """Persist FAISS indexes to disk."""
+    for name, rag in rags.items():
+        if hasattr(rag, "save_local"):
+            path = os.path.join(RAG_INDEX_DIR, name)
+            os.makedirs(path, exist_ok=True)
+            rag.save_local(path)
+    logging.info("RAG индексы сохранены на диск")
+
+
+async def periodic_save_rags(interval: int = 900) -> None:
+    """Save RAG indexes every `interval` seconds."""
+    while True:
+        await asyncio.sleep(interval)
+        current = get_rags()
+        if not current:
+            logging.info("RAG модели еще не загружены, пропускаю сохранение")
+            continue
+        try:
+            save_rags_to_disk(current)
+        except Exception as e:
+            logging.error(f"Ошибка при сохранении RAG моделей: {e}")
+
+
+async def main():
     app = Client(
         SESSION_NAME,
         api_id=int(API_ID),
         api_hash=API_HASH,
         bot_token=TELEGRAM_BOT_TOKEN
     )
-    logging.info("Бот запущен. Ожидаю сообщений...")
 
-    # Подключаем все обработчики
     register_handlers(app)
 
-    # Запуск бота
-    app.run()
+    await app.start()
+    asyncio.create_task(load_rags())
+    asyncio.create_task(periodic_save_rags())
+    logging.info("Бот запущен. Ожидаю сообщений...")
+    await idle()
+    await app.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 # Тест автоматического деплоя - Tue Aug 26 08:56:17 EDT 2025
 # Webhook test comment added at Tue Aug 26 08:56:17 EDT 2025
 # Второй тест webhook деплоя - Tue Aug 26 08:57:57 EDT 2025


### PR DESCRIPTION
## Summary
- persist RAG FAISS indexes on disk and refresh every 15 minutes
- expose `get_rags` helper for saving
- fix use of nonexistent `app.idle()` by switching to `idle()`

## Testing
- `python3 -m py_compile src/config.py src/handlers.py src/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b167b1fd408331838bd3090a55c736