### PR TITLE
feat: reuse cached rag indices

### DIFF
--- a/src/rag_persistence.py
+++ b/src/rag_persistence.py
@@ -4,6 +4,7 @@ from langchain_community.vectorstores import FAISS
 
 from config import RAG_INDEX_DIR
 from storage import safe_filename
+from utils import get_embedding_model, CustomSentenceTransformerEmbeddings
 
 
 def save_rag_indices(rags: dict) -> None:
@@ -15,3 +16,21 @@ def save_rag_indices(rags: dict) -> None:
         path = os.path.join(RAG_INDEX_DIR, safe_filename(name))
         shutil.rmtree(path, ignore_errors=True)
         index.save_local(path)
+
+
+def load_rag_indices() -> dict:
+    """Load FAISS indices from disk."""
+    model = get_embedding_model()
+    embeddings = CustomSentenceTransformerEmbeddings(model)
+    rags = {}
+
+    for name in os.listdir(RAG_INDEX_DIR):
+        path = os.path.join(RAG_INDEX_DIR, name)
+        if not os.path.isdir(path):
+            continue
+        try:
+            rags[name] = FAISS.load_local(path, embeddings)
+        except Exception:
+            continue
+
+    return rags

--- a/src/run_analysis.py
+++ b/src/run_analysis.py
@@ -16,8 +16,9 @@ from markups import interview_menu_markup, design_menu_markup, main_menu_markup,
 from analysis import analyze_methodology, classify_query, extract_from_chunk_parallel, aggregate_citations, classify_report_type, generate_db_answer, extract_from_chunk_parallel_async
 from storage import save_user_input_to_db, build_reports_grouped, create_db_in_memory
 
-def init_rags() -> dict:
-    rags = {}
+
+def init_rags(existing_rags: dict | None = None) -> dict:
+    rags = existing_rags.copy() if existing_rags else {}
     rag_configs = [
         ("Интервью", None, None),
         ("Дизайн", None, None),
@@ -33,10 +34,12 @@ def init_rags() -> dict:
     for config in rag_configs:
         scenario_name, report_type, _ = config
         try:
+            rag_name = report_type if report_type else scenario_name
+            if rag_name in rags:
+                continue
             content = build_reports_grouped(scenario_name=scenario_name, report_type=report_type)
             content_str = grouped_reports_to_string(content)
-            rag_name = report_type if report_type else scenario_name
-            
+
             if rag_name == "Интервью" or rag_name == "Дизайн":
                 rag_db = create_db_in_memory(content_str)
                 rags[rag_name] = rag_db


### PR DESCRIPTION
## Summary
- load saved FAISS indices from disk
- skip rebuilding existing RAG indices
- initialize bot with cached RAGs when available

## Testing
- `python -m py_compile src/rag_persistence.py src/main.py src/run_analysis.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b28ecb996c8331ace56be70f964f88