### PR TITLE
Ensure MinIO bucket exists before use

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -63,6 +63,13 @@ minio_client = Minio(
     secure=False
 )
 
+try:
+    if not minio_client.bucket_exists(MINIO_BUCKET_NAME):
+        minio_client.make_bucket(MINIO_BUCKET_NAME)
+except S3Error as err:
+    logging.error("Не удалось создать бакет %s: %s", MINIO_BUCKET_NAME, err)
+    print("Не удалось создать бакет для хранения файлов. Проверьте настройки MinIO.")
+
 filter_wav_document = filters.create(openai_audio_filter)
 
 audio_file_name_to_save = ""


### PR DESCRIPTION
## Summary
- Initialize MinIO bucket on startup and log errors if creation fails

## Testing
- `python -m py_compile src/handlers.py`
- `python - <<'PY'
from unittest.mock import MagicMock
import logging
class S3Error(Exception):
    pass

MINIO_BUCKET_NAME='bucket'
minio_client=MagicMock()
minio_client.bucket_exists.return_value=False

try:
    if not minio_client.bucket_exists(MINIO_BUCKET_NAME):
        minio_client.make_bucket(MINIO_BUCKET_NAME)
except S3Error as err:
    logging.error("Не удалось создать бакет %s: %s", MINIO_BUCKET_NAME, err)
    print("Не удалось создать бакет для хранения файлов. Проверьте настройки MinIO.")

print('make_bucket called:', minio_client.make_bucket.called)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b2e4b15cf48331b201c1881c3abb08