### PR TITLE
feat: add dedicated minio audio bucket

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,6 +35,7 @@ RUN_MODE=PROD
 # MinIO Configuration (опционально)
 MINIO_ENDPOINT=your_minio_endpoint_here
 MINIO_BUCKET_NAME=your_bucket_name_here
+MINIO_AUDIO_BUCKET_NAME=voxpersona-audio
 MINIO_ACCESS_KEY=your_minio_access_key_here
 MINIO_SECRET_KEY=your_minio_secret_key_here
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       # MinIO
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
       - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME:-}
+      - MINIO_AUDIO_BUCKET_NAME=${MINIO_AUDIO_BUCKET_NAME:-voxpersona-audio}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-}
     depends_on:

--- a/src/config.py
+++ b/src/config.py
@@ -54,9 +54,10 @@ else:
     TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
     SESSION_NAME = os.getenv("SESSION_BOT_NAME")
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")  
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
+MINIO_AUDIO_BUCKET_NAME = os.getenv("MINIO_AUDIO_BUCKET_NAME", "voxpersona-audio")
 
 # Проверяем, что все ключи заданы
 if not all([OPENAI_API_KEY, ANTHROPIC_API_KEY, TELEGRAM_BOT_TOKEN, API_ID, API_HASH]):

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -16,6 +16,7 @@ from config import (
     MINIO_ACCESS_KEY,
     MINIO_SECRET_KEY,
     MINIO_BUCKET_NAME,
+    MINIO_AUDIO_BUCKET_NAME,
     STORAGE_DIRS
 )
 from utils import run_loading_animation, openai_audio_filter
@@ -64,10 +65,11 @@ minio_client = Minio(
 )
 
 try:
-    if not minio_client.bucket_exists(MINIO_BUCKET_NAME):
-        minio_client.make_bucket(MINIO_BUCKET_NAME)
+    for bucket in [MINIO_BUCKET_NAME, MINIO_AUDIO_BUCKET_NAME]:
+        if bucket and not minio_client.bucket_exists(bucket):
+            minio_client.make_bucket(bucket)
 except S3Error as err:
-    logging.error("Не удалось создать бакет %s: %s", MINIO_BUCKET_NAME, err)
+    logging.error("Не удалось создать бакет %s: %s", bucket, err)
     print("Не удалось создать бакет для хранения файлов. Проверьте настройки MinIO.")
 
 filter_wav_document = filters.create(openai_audio_filter)
@@ -644,9 +646,9 @@ def register_handlers(app: Client):
             audio_file_name_to_save = os.path.basename(downloaded)
 
             minio_client.fput_object(
-                MINIO_BUCKET_NAME,
-                file_name,  
-                downloaded  
+                MINIO_AUDIO_BUCKET_NAME,
+                file_name,
+                downloaded
             )
             logging.info(f"Аудиофайл {file_name} успешно загружен в MinIO.")
 


### PR DESCRIPTION
## Summary
- add `MINIO_AUDIO_BUCKET_NAME` constant
- ensure MinIO audio bucket exists and use it for audio uploads
- expose `MINIO_AUDIO_BUCKET_NAME` env var in templates and docker compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2eb4b56188331868201275f7192c6