### PR TITLE
Persist RAG indices volume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Exclude runtime data from Docker build context
+logs/
+rag_indices/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - postgres
     volumes:
       - ./logs:/app/logs
+      - ./rag_indices:/app/rag_indices
 
   postgres:
     image: postgres:14


### PR DESCRIPTION
## Summary
- mount host `rag_indices` directory into the container to persist RAG indices between rebuilds
- exclude `rag_indices` and logs from Docker build context

## Testing
- `python -m pytest`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f30f9ea083318b0dcd33abb69a99