### PR TITLE
fix: persist RAG indices in volume

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -83,7 +83,8 @@ for fold in STORAGE_DIRS.values():
 PROMPTS_DIR = "/root/Vox/VoxPersona/prompts"
 
 # Каталог для сохранения RAG индексов
-RAG_INDEX_DIR = "rag_indices"
+# Используем абсолютный путь, чтобы сохранять данные в смонтированную volume-директорию
+RAG_INDEX_DIR = "/app/rag_indices"
 os.makedirs(RAG_INDEX_DIR, exist_ok=True)
 
 try:


### PR DESCRIPTION
## Summary
- store RAG index data under /app/rag_indices so files are written to the mounted volume
- attempt an immediate save when indices directory is empty and swallow failures so the next save can succeed
- guard periodic RAG saves against write errors

## Testing
- `python -m py_compile src/config.py src/main.py src/rag_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2fac5281c8331a32ac6c47d39acc0